### PR TITLE
Changed "transparency" to "opacity" in Navigation Bar settings

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -183,7 +183,7 @@
     <string name="navbar_qty_title">Navigation button quantity</string>
     <string name="navbar_qty_summary">Choose the number of navigation buttons</string>
     <string name="navbar_action_title">Button %1$s action &amp; icon</string>
-    <string name="button_transparency_title">Nav button transparency</string>
+    <string name="button_transparency_title">Nav button opacity</string>
     <string name="navbar_longpress_title">Button %1$s longpress action</string>
     <string name="navbar_action_home">Home</string>
     <string name="navbar_action_back">Back</string>


### PR DESCRIPTION
In the Navigation Bar section of ROM Control, the last setting listed is "Nav button transparency". Setting this value to 0% makes the navigation buttons completely invisible (transparent), while setting it to 100% makes the buttons entirely opaque (not transparent); this behavior is the opposite of what the wording seems to imply.

While it becomes apparent how this feature actually works almost immediately upon adjusting the slider, it might be a good idea to fix this just for consistency/clarity.

I propose simply rewording this setting to be "Nav button opacity" (and have done so in the attached Pull Request). Alternative solutions such as putting 100% on the left side and 0% on the right, or decreasing brightness (increasing transparency) as you slide to the right, would also resolve this inconsistency, although at the expense of intuitiveness.

Thanks!
